### PR TITLE
Duplicate running for large files

### DIFF
--- a/lib/rocket_job/dirmon_entry.rb
+++ b/lib/rocket_job/dirmon_entry.rb
@@ -14,6 +14,10 @@ module RocketJob
 
     # User defined name used to identify this DirmonEntry in the Web Interface.
     field :name, type: String
+    
+    # Interval to run each instance
+    field :run_interval, type: Integer, default: 0
+    field :last_run_at, type: Time, default: Time.now
 
     # Pattern for finding files
     #
@@ -226,6 +230,9 @@ module RocketJob
 
     # Archives the file, then kicks off a file upload job to upload the archived file.
     def later(iopath)
+      return if self.last_run_at + self.run_interval.minutes > Time.now
+      
+      update_attribute(:last_run_at, Time.now)
       job_id       = BSON::ObjectId.new
       archive_path = archive_iopath(iopath).join("#{job_id}_#{iopath.basename}")
       iopath.move_to(archive_path)

--- a/lib/rocket_job/jobs/dirmon_job.rb
+++ b/lib/rocket_job/jobs/dirmon_job.rb
@@ -69,7 +69,7 @@ module RocketJob
           # Skip file size checking since S3 files are only visible once completely uploaded.
           unless path.partial_files_visible?
             logger.info("File: #{path}. Starting: #{dirmon_entry.job_class_name}")
-            dirmon_entry.later(path)
+            dirmon_entry.process(path)
             next
           end
 
@@ -92,7 +92,7 @@ module RocketJob
         size = path.size
         if previous_size && (previous_size == size)
           logger.info("File stabilized: #{path}. Starting: #{dirmon_entry.job_class_name}")
-          dirmon_entry.later(path)
+          dirmon_entry.process(path)
           nil
         else
           logger.info("Found file: #{path}. File size: #{size}")

--- a/test/dirmon_entry_test.rb
+++ b/test/dirmon_entry_test.rb
@@ -284,6 +284,19 @@ class DirmonEntryTest < Minitest::Test
         end
       end
 
+      describe "#process" do
+        it "calls later without changing state" do
+          dirmon_entry.process(iopath)
+          assert [nil, "enabled"], dirmon_entry.previous_changes.dig("state")
+        end
+
+        it "calls later after changing state" do
+          dirmon_entry.enable_parallel_processing = false
+          dirmon_entry.process(iopath)
+          assert ["queued", "enabled"], dirmon_entry.previous_changes.dig("state")
+        end
+      end
+
       describe "#later" do
         it "enqueues job" do
           job = dirmon_entry.later(iopath)


### PR DESCRIPTION
Currently large files processing taking time, if it takes more than cron schedule interval time same file is getting reprocessed 
again which is creating duplicate records.

This PR should help eliminating duplicate processing for Dirmon entry. 