### PR TITLE
Fixing typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ These fields have been removed from the job itself:
 ~~~ruby
 class MyJob < RocketJob::Job
   include RocketJob::Batch
-  
-  self.slice_sice = 1_000
+
+  self.slice_size = 1_000
   self.encrypt    = true
   self.compress   = true
 end
@@ -123,8 +123,8 @@ If the serializer is set to `encrypt` then it is automatically compressed.
 ~~~ruby
 class MyJob < RocketJob::Job
   include RocketJob::Batch
-  
-  input_category slice_sice: 1_000, serializer: :encrypt
+
+  input_category slice_size: 1_000, serializer: :encrypt
 end
 ~~~
 


### PR DESCRIPTION
The documentation said `slice_sice` instead of `slice_size`.

### Issue # (if available)


### Description of changes

There was a typo `slice_sice` instead of `slice_size`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
