### PR TITLE
Exception raises in throttle check

### DIFF
--- a/lib/rocket_job/thread_worker.rb
+++ b/lib/rocket_job/thread_worker.rb
@@ -27,6 +27,7 @@ module RocketJob
 
     # Send each active worker the RocketJob::ShutdownException so that stops processing immediately.
     def kill
+      requeue_jobs
       @thread.raise(Shutdown, "Shutdown due to kill request for worker: #{name}") if @thread.alive?
     end
 

--- a/lib/rocket_job/throttle_definition.rb
+++ b/lib/rocket_job/throttle_definition.rb
@@ -22,7 +22,7 @@ module RocketJob
       job.logger.debug { "Throttle: #{method_name} has been exceeded." }
       true
     rescue Exception => e
-      job.logger.error("Throttle failed.", e)
+      job.logger.error("#{job.class.name} Throttle failed at #{method_name}.", e)
       true
     end
 

--- a/lib/rocket_job/throttle_definition.rb
+++ b/lib/rocket_job/throttle_definition.rb
@@ -21,6 +21,9 @@ module RocketJob
 
       job.logger.debug { "Throttle: #{method_name} has been exceeded." }
       true
+    rescue Exception => e
+      job.logger.error("Throttle failed.", e)
+      true
     end
 
     # Returns the filter to apply to the job when the above throttle returns true.

--- a/lib/rocket_job/version.rb
+++ b/lib/rocket_job/version.rb
@@ -1,3 +1,3 @@
 module RocketJob
-  VERSION = "6.1.0".freeze
+  VERSION = "6.1.1".freeze
 end

--- a/lib/rocket_job/worker.rb
+++ b/lib/rocket_job/worker.rb
@@ -23,7 +23,7 @@ module RocketJob
       @re_check_start = Time.now
       @current_filter = Config.filter || {}
     end
-
+    
     def alive?
       true
     end
@@ -51,6 +51,17 @@ module RocketJob
     # Returns [true|false] whether the shutdown indicator was set
     def wait_for_shutdown?(_timeout = nil)
       false
+    end
+
+    # Requeue Jobs running on this worker before removing it from pool
+    def requeue_jobs
+      puts "Requeue Jobs running on this worker before removing it from pool"
+      logger.error "Requeue Jobs running on this worker before removing it from pool"
+      query = RocketJob::Job.where(:state.in => %i[running paused failed aborted])
+      query = query.where(worker_name: name)
+      query.each do |job|
+        job.requeue!(name)
+      end
     end
 
     # Process jobs until it shuts down

--- a/lib/rocket_job/worker_pool.rb
+++ b/lib/rocket_job/worker_pool.rb
@@ -49,6 +49,7 @@ module RocketJob
       return 0 if remove_count.zero?
 
       logger.info "Cleaned up #{remove_count} dead workers"
+      workers.each { |t| t.requeue_jobs unless t.alive? }
       workers.delete_if { |t| !t.alive? }
       remove_count
     end

--- a/test/plugins/job/throttle_test.rb
+++ b/test/plugins/job/throttle_test.rb
@@ -55,6 +55,16 @@ module Plugins
         end
       end
 
+      class FailedThrottledJob < BaseJob
+        define_throttle :failed_throttle
+
+        private
+
+        def failed_throttle
+          abc # raises undefined method abc
+        end
+      end
+
       describe RocketJob::Plugins::Job::Throttle do
         before do
           RocketJob::Job.delete_all
@@ -169,6 +179,13 @@ module Plugins
             job1.fail!
             job2 = ThrottleGroupJob.new
             refute job2.send(:throttle_running_jobs_exceeded?)
+          end
+        end
+
+        describe "#throttle_failed_methods" do
+          it "throttles job if matching filter fails" do
+            job = FailedThrottledJob.new
+            assert job.rocket_job_throttles.matching_filter(job)
           end
         end
       end


### PR DESCRIPTION
## Exception in throttles
If exception raises in throttle checks its adding error logs but not nullifying worker names for Jobs and Slices, due to this reason jobs are becoming jombie jobs.

If exception raises log error and return true which will eventually updates slice and jobs worker names and reque the jobs/slices.

## Requeue jobs before removing worker from pool
Every few seconds we run prune to delete dead workers from pool but jobs are still on that worker name. If we requeue jobs 
everytime before removing workers from pool, jobs will be queued immediately instead of waiting till server goes down.

##
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
