### PR TITLE
Add a default priority of 30 for Copy File Job.

### DIFF
--- a/lib/rocket_job/jobs/copy_file_job.rb
+++ b/lib/rocket_job/jobs/copy_file_job.rb
@@ -26,6 +26,7 @@ module RocketJob
       self.destroy_on_complete = false
       # Number of times to automatically retry the copy. Set to `0` for no retry attempts.
       self.retry_limit = 10
+      self.prioriy = 30
 
       # File names in IOStreams URL format.
       field :source_url, type: String, user_editable: true


### PR DESCRIPTION
### Description of changes
Adding a default priority to the CopyFileJob so it will run quickly and not get stuck behind lower priority jobs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
